### PR TITLE
feat: Manage cart global state to add products

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-aspect-ratio": "^1.0.3",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-toast": "^1.1.5",
         "@reduxjs/toolkit": "^2.2.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
@@ -25,7 +26,8 @@
         "react-redux": "^9.1.0",
         "sharp": "^0.33.3",
         "tailwind-merge": "^2.2.2",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "vaul": "^0.9.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1255,6 +1257,40 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.1.5.tgz",
+      "integrity": "sha512-fRLn227WHIBRSzuRzGJ8W+5YALxofH23y0MlPLddaIpLpCDqdE0NZlS2NRQDRiptfxDeeCjgFIpexB1/zkxDlw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
@@ -1321,6 +1357,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
+      "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -6028,6 +6087,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/vaul": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-0.9.0.tgz",
+      "integrity": "sha512-bZSySGbAHiTXmZychprnX/dE0EsSige88xtyyL3/MCRbrFotRPQZo7UdydGXZWw+CKbNOw5Ow8gwAo93/nB/Cg==",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.0.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-aspect-ratio": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-toast": "^1.1.5",
     "@reduxjs/toolkit": "^2.2.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
@@ -26,7 +27,8 @@
     "react-redux": "^9.1.0",
     "sharp": "^0.33.3",
     "tailwind-merge": "^2.2.2",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "vaul": "^0.9.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,6 +81,17 @@
     scrollbar-width: none;
     -ms-overflow-style: none;
   }
+
+  /* Hide the increment and decrement buttons on input type number */
+  input[type="number"]::-webkit-inner-spin-button,
+  input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  input[type="number"] {
+    -moz-appearance: textfield; /* Firefox */
+  }
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import "./globals.css";
 import type { Metadata } from "next";
 import { Plus_Jakarta_Sans } from "next/font/google";
+import { Toaster } from "@/components/ui/toaster";
 
 const jakarta = Plus_Jakarta_Sans({
   subsets: ["latin"],
@@ -37,6 +38,7 @@ export default function RootLayout({
           <Container>
             <Navbar />
             {children}
+            <Toaster />
           </Container>
         </body>
       </html>

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -4,6 +4,8 @@ import { useAppDispatch } from "@/lib/hooks";
 import { fetchCategoriesAsync } from "@/lib/features/categoriesSlice";
 import { fetchFeaturedProductsAsync } from "@/lib/features/featuredProductsSlice";
 import React, { useEffect } from "react";
+import { setCart } from "@/lib/features/cartSlice";
+import { Cart } from "@/lib/types";
 
 type Props = {
   children: React.ReactNode;
@@ -14,6 +16,15 @@ export default function HomeTemplate(props: Props) {
   const { children } = props;
 
   useEffect(() => {
+    const rawCart = localStorage.getItem("cart");
+
+    if (rawCart) {
+      const cart: Cart[] = JSON.parse(rawCart);
+      dispatch(setCart(cart));
+    } else {
+      dispatch(setCart([]));
+    }
+
     dispatch(fetchCategoriesAsync());
     dispatch(fetchFeaturedProductsAsync());
   }, [dispatch]);

--- a/src/components/cart-item-card.tsx
+++ b/src/components/cart-item-card.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { priceToIDR } from "@/lib/utils";
+import Image from "next/image";
+import React, { useState } from "react";
+
+import { Plus, Minus, Trash2 } from "lucide-react";
+import { useAppDispatch, useAppSelector, useCounter } from "@/lib/hooks";
+import { setCart } from "@/lib/features/cartSlice";
+
+interface Props {
+  sku: string;
+  title: string;
+  image: string;
+  price: number;
+  qty: number;
+  discount?: number;
+}
+
+const CartItemCard: React.FC<Props> = (props) => {
+  const { image, price, title, discount, qty, sku } = props;
+
+  const priceIDR = priceToIDR(price);
+  const fixPrice = discount ? price - (price * discount) / 100 : price;
+
+  const dispatch = useAppDispatch();
+  const { data } = useAppSelector((state) => state.cart);
+  const { counter, total, handleDecrement, handleIncrement } = useCounter(
+    qty,
+    fixPrice,
+  );
+
+  const index = data.findIndex((product) => product.sku === sku);
+
+  const handleDeleteProduct = (index: number) => {
+    const newCart = [...data];
+    newCart.splice(index, 1);
+
+    dispatch(setCart(newCart));
+    localStorage.setItem("cart", JSON.stringify(newCart));
+  };
+
+  return (
+    <div className="flex gap-2 rounded-lg bg-white px-4 py-2">
+      <div className="relative h-[110px] min-w-[110px] overflow-hidden rounded bg-[#EAEAEA] md:h-[114px] md:min-w-[114px]">
+        <Image
+          alt={title}
+          src={image}
+          fill
+          sizes="100vw"
+          className="object-contain"
+        />
+      </div>
+      <div className="flex w-full flex-col justify-between">
+        <div className="flex items-start justify-between">
+          <p className="line-clamp-2 flex-1 font-bold md:text-lg md:leading-normal">
+            {title}
+          </p>
+          <button
+            type="button"
+            onClick={() => handleDeleteProduct(index)}
+            className="flex-0 ml-3 flex h-6 w-6 items-center justify-center rounded border bg-gray text-red-400 lg:h-7 lg:w-7"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+        <div>
+          <div className="flex gap-6 py-2 text-xs font-medium text-[#181818] md:text-sm">
+            {discount ? (
+              <p>Rp.{priceToIDR(price - (price * discount) / 100)}</p>
+            ) : null}
+            <p>
+              {discount ? (
+                <s className="text-[#909090]">Rp.{priceIDR}</s>
+              ) : (
+                `Rp.${priceIDR}`
+              )}
+            </p>
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center">
+              <button
+                type="button"
+                disabled={counter <= 1}
+                onClick={() => handleDecrement(true, index)}
+                className="flex h-6 w-6 items-center justify-center rounded border bg-gray font-bold focus:bg-green disabled:text-black/20 lg:h-7 lg:w-7"
+              >
+                <Minus className="h-4 w-4" />
+              </button>
+              <span className="h-6 w-12 text-center lg:h-7">{counter}</span>
+              <button
+                type="button"
+                onClick={() => handleIncrement(true, index)}
+                className="flex h-6 w-6 items-center justify-center rounded border bg-gray font-bold focus:bg-green lg:h-7 lg:w-7"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+            </div>
+            <span className="text-xs font-bold md:text-sm">
+              Rp.{priceToIDR(total)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CartItemCard;

--- a/src/components/home/featured-product-card.tsx
+++ b/src/components/home/featured-product-card.tsx
@@ -75,6 +75,7 @@ const FeaturedProductCardWrapper = () => {
               sold={Number(product.acf.sold)}
               title={product.title.rendered}
               discount={Number(product.acf.discount)}
+              sku={product.acf.sku}
             />
           ))}
         </div>

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+);
+Drawer.displayName = "Drawer";
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed bottom-0 right-0 z-50 mt-24 flex h-full w-full flex-col border bg-background md:w-[400px] lg:w-[500px]",
+        className,
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = "DrawerContent";
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+);
+DrawerHeader.displayName = "DrawerHeader";
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+);
+DrawerFooter.displayName = "DrawerFooter";
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed bottom-0 right-0 top-auto z-[100] flex max-h-screen w-full flex-col p-4 md:max-w-[420px]",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className,
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold", className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+};

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast"
+import { useToast } from "@/components/ui/use-toast"
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,0 +1,194 @@
+"use client"
+
+// Inspired by react-hot-toast library
+import * as React from "react"
+
+import type {
+  ToastActionElement,
+  ToastProps,
+} from "@/components/ui/toast"
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"]
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"]
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      }
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/src/lib/features/cartSlice.ts
+++ b/src/lib/features/cartSlice.ts
@@ -1,0 +1,24 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { Cart } from "../types";
+
+type CartState = {
+  data: Cart[];
+};
+
+const initialState: CartState = {
+  data: [],
+};
+
+const cartSlice = createSlice({
+  name: "cart",
+  initialState,
+  reducers: {
+    setCart: (state, action: PayloadAction<Cart[]>) => {
+      state.data = action.payload;
+    },
+  },
+});
+
+export const { setCart } = cartSlice.actions;
+
+export default cartSlice.reducer;

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,7 +1,72 @@
 import { useDispatch, useSelector, useStore } from "react-redux";
 import type { RootState, AppDispatch, AppStore } from "./store";
+import { useState } from "react";
+import { Cart } from "./types";
+import { setCart } from "./features/cartSlice";
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();
 export const useAppStore = useStore.withTypes<AppStore>();
+
+export const useCounter = (initialCounter: number, price: number) => {
+  const dispatch = useAppDispatch();
+  const { data } = useAppSelector((state) => state.cart);
+  const [counter, setCounter] = useState(initialCounter);
+  const [total, setTotal] = useState(price * initialCounter);
+
+  const handleIncrement = (
+    isUpdateGlobalState: boolean = false,
+    indexOfItem: null | number = null,
+  ) => {
+    const totalCounter = counter + 1;
+
+    setCounter(totalCounter);
+    setTotal(price * totalCounter);
+
+    if (isUpdateGlobalState && indexOfItem !== null) {
+      const newCart = [...data];
+
+      const updatedProductQty: Cart = {
+        ...newCart[indexOfItem],
+        qty: newCart[indexOfItem].qty + 1,
+      };
+
+      newCart[indexOfItem] = updatedProductQty;
+      dispatch(setCart(newCart));
+      localStorage.setItem("cart", JSON.stringify(newCart));
+    }
+  };
+
+  const handleDecrement = (
+    isUpdateGlobalState: boolean = false,
+    indexOfItem: null | number = null,
+  ) => {
+    const totalCounter = counter - 1;
+
+    setCounter(totalCounter);
+    setTotal(price * totalCounter);
+
+    if (isUpdateGlobalState && indexOfItem !== null) {
+      const newCart = [...data];
+
+      const updatedProductQty: Cart = {
+        ...newCart[indexOfItem],
+        qty: newCart[indexOfItem].qty - 1,
+      };
+
+      newCart[indexOfItem] = updatedProductQty;
+      dispatch(setCart(newCart));
+      localStorage.setItem("cart", JSON.stringify(newCart));
+    }
+  };
+
+  return {
+    counter,
+    setCounter,
+    total,
+    setTotal,
+    handleIncrement,
+    handleDecrement,
+  };
+};

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,6 @@
 import categoriesReducer from "./features/categoriesSlice";
 import featuredProductsReducer from "./features/featuredProductsSlice";
+import cartSliceReducer from "./features/cartSlice";
 import { configureStore } from "@reduxjs/toolkit";
 
 export const makeStore = () => {
@@ -7,6 +8,7 @@ export const makeStore = () => {
     reducer: {
       categories: categoriesReducer,
       featuredProducts: featuredProductsReducer,
+      cart: cartSliceReducer,
     },
   });
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,6 +34,7 @@ export type Product = {
     rendered: string;
   };
   acf: {
+    sku: string;
     category: {
       term_id: number;
       name: string;
@@ -52,4 +53,13 @@ export type Product = {
     rating: string;
     discount?: string;
   };
+};
+
+export type Cart = {
+  sku: string;
+  title: string;
+  image: string;
+  price: number;
+  discount?: number;
+  qty: number;
 };


### PR DESCRIPTION
- Hide increment and decrement buttons on the "input" of type "number".
- Integrate the Toaster component into "layout.tsx".
- Create a slice for cart and define the "setCart" action.
- Set the cart global state in "template.tsx".
- Develop the "cart-item-card" component.
- Create a custom hook "useCounter" to manage product qty, total amount (qty * fixed price), and functionality to increment and decrement qty.
- Update the state in "product-card-wrapper" using the state provided by "useCounter".
- Utilize the drawer and toast components from shadcn/ui.
- Define a type for Cart.
- Enhance the navbar component by adding a drawer triggered by clicking the cart button.